### PR TITLE
Reorder the elements in circle-slash.svg

### DIFF
--- a/icons/circle-slash.svg
+++ b/icons/circle-slash.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <line x1="9" x2="15" y1="15" y2="9" />
   <circle cx="12" cy="12" r="10" />
+  <line x1="9" x2="15" y1="15" y2="9" />
 </svg>


### PR DESCRIPTION
## What is the purpose of this pull request?
- Bug fix

### Description
Adding a fill value to the CircleSlash React component caused the line element to be painted over.

This was due to the ordering of the elements within the SVG. Elements are painted in the order they are listed.

This commit swaps the ordering of the elements.

## Before Submitting <!-- For every PR! -->
<!-- All of these requirements must be fulfilled. -->
- [x] I've read the [Contribution Guidelines](https://github.com/lucide-icons/lucide/blob/main/CONTRIBUTING.md).
- [x] I've checked if there was an existing PR that solves the same issue.
